### PR TITLE
Changed JSON responses to follow JSON API convention

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -26,7 +26,7 @@ class AuthController extends Controller
      */
     public function getUser()
     {
-        return response()->json(Auth::user());
+        return response()->json(['data' => Auth::user()]);
     }
 
     /**
@@ -42,11 +42,13 @@ class AuthController extends Controller
 
         if (!$token) {
             return response()->json([
-                'message' => 'Unauthorized'
+                'errors' => [
+                'title' => 'Unauthorized'
+                ]
             ], 401);
         }
 
-        return response()->json(['user' => Auth::user(), 'token' => $token]);
+        return response()->json(['data' => ['user' => Auth::user(), 'token' => $token]]);
     }
 
     /**
@@ -64,7 +66,7 @@ class AuthController extends Controller
 
         Mail::to($user)->send(new Welcome($user));
 
-        return response()->json(['message' => 'Account created. Please verify via email.']);
+        return response()->json(['data' => ['message' => 'Account created. Please verify via email.']]);
     }
 
     /**
@@ -78,10 +80,10 @@ class AuthController extends Controller
         $user = User::verifyByToken($token);
 
         if (!$user) {
-            return response()->json(['message' => 'Invalid verification token'], 400);
+            return response()->json(['data' => ['message' => 'Invalid verification token']], 400);
         }
 
-        return response()->json(['message' => 'Account has been verified']);
+        return response()->json(['data' => ['message' => 'Account has been verified']]);
     }
 
     /**

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -41,7 +41,9 @@ class Authenticate
     {
         if ($this->auth->guard($guard)->guest()) {
             return response()->json([
-                'message' => 'Unauthorized'
+                'errors' => [
+                    'title' => 'Unauthorized'
+                ]
             ], 401);
         }
 

--- a/app/Http/Middleware/CorsMiddleware.php
+++ b/app/Http/Middleware/CorsMiddleware.php
@@ -26,7 +26,7 @@ class CorsMiddleware
     public function handle($request, Closure $next)
     {
         if (!$allowedOrigin = env('ALLOWED_ORIGIN')) {
-            return response()->json(['message' => 'No valid cors settings found!'], 401);
+            return response()->json(['data' => ['message' => 'No valid cors settings found!']], 401);
         }
 
         $headers = [


### PR DESCRIPTION
For example, vue-auth expects the user data to be wrapped in a data object (according to the JSON API convention).

jsonapi.org